### PR TITLE
機能: ピースプレビューがマウスカーソルに追従するようにする

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,6 +273,9 @@
                     return;
                 }
 
+                // プレビューを常に表示
+                piecePreviewContainer.style.display = 'grid';
+
                 const boardRect = boardContainer.getBoundingClientRect();
                 const mouseX = e.clientX;
                 const mouseY = e.clientY;
@@ -282,8 +285,7 @@
                                          mouseY >= boardRect.top && mouseY < boardRect.bottom;
 
                 if (isMouseOverBoard) {
-                    piecePreviewContainer.style.display = 'grid';
-                    // ボードの左上を基準としたマウス座標
+                    // ボード上：グリッドにスナップ
                     const relativeMouseX = mouseX - boardRect.left;
                     const relativeMouseY = mouseY - boardRect.top;
 
@@ -301,8 +303,12 @@
                     const isValid = isValidPlacement(startX, startY, selectedPieceData);
                     piecePreviewContainer.classList.toggle('invalid-placement', !isValid);
                 } else {
-                    // ボードの外ではプレビューを非表示
-                    piecePreviewContainer.style.display = 'none';
+                    // ボード外：カーソルに追従
+                    const previewX = mouseX - boardRect.left - (pieceAnchor.x * cellWidth) - (cellWidth / 2);
+                    const previewY = mouseY - boardRect.top - (pieceAnchor.y * cellHeight) - (cellHeight / 2);
+
+                    piecePreviewContainer.style.transform = `translate(${previewX}px, ${previewY}px)`;
+                    piecePreviewContainer.classList.remove('invalid-placement');
                 }
             }
 


### PR DESCRIPTION
このコミットは、選択したピースのプレビューがゲームボード上にカーソルがあるときだけ表示されるのではなく、継続的にマウスカーソルに追従するようにすることで、ユーザーエクスペリエンスを向上させます。

`handleGlobalMouseMove`関数は次のように更新されました。
- ピースが選択されている場合は常にプレビューを表示します。
- カーソルがボード上にあるときはプレビューをグリッドにスナップさせ、正確な配置ガイドを維持します。
- ボード外ではプレビューがカーソルにスムーズに追従し、常に視覚的なフィードバックを提供します。